### PR TITLE
Fixed some mistakes

### DIFF
--- a/waifu.yml
+++ b/waifu.yml
@@ -677,10 +677,6 @@
   series: Tokyo Ravens
 - name: Miyo Kurahashi
   series: Tokyo Ravens
-- name: Fumi Hasegawa
-  series: Tokyo Ravens
-- name: Yoriko Matsumoto
-  series: Tokyo Ravens
   
   # Higurashi no Naku Koro ni
 - name: Rena Ryugu


### PR DESCRIPTION
- `Rise Kujiwaka` → `Rise Kujikawa`
- Removed `Fumi Hasegawa` and `Yoriko Matsumoto` from _Tokyo Ravens_ because they're from _Yuyushiki_ (and already in the _Yuyushiki_ list)
