### PR TITLE
Fix name order of PSG girls

### DIFF
--- a/waifu.yml
+++ b/waifu.yml
@@ -1147,9 +1147,9 @@
   series: Gochuumon wa Usagi Desu ka?
 
 # Panty and Stocking with Garterbelt
-- name: Anarchy Panty
+- name: Panty Anarchy
   series: Panty and Stocking with Garterbelt
-- name: Anarchy Stocking
+- name: Stocking Anarchy
   series: Panty and Stocking with Garterbelt
 - name: Briefers Rock
   series: Panty and Stocking with Garterbelt


### PR DESCRIPTION
For consistency, corrected Panty and Stocking to use Western name order.
